### PR TITLE
Feature/kafka consumer

### DIFF
--- a/src/main/java/com/allknu/backend/configuration/KafkaConsumerConfig.java
+++ b/src/main/java/com/allknu/backend/configuration/KafkaConsumerConfig.java
@@ -1,0 +1,65 @@
+package com.allknu.backend.configuration;
+
+
+import com.allknu.backend.kafka.dto.MLRequestMessage;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EnableKafka
+@Configuration
+public class KafkaConsumerConfig {
+    @Value("${spring.kafka.consumer.group-id}")
+    private String groupId;
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String brokers;
+    @Value("${spring.kafka.consumer.auto-offset-reset}")
+    private String offsetReset;
+
+    @Bean
+    public NewTopic mlRequestTopic() {
+        return TopicBuilder.name("mlRequest")
+                .partitions(1)
+                .replicas(1)
+                .build();
+    }
+
+    @Bean
+    public ConsumerFactory<String, MLRequestMessage> MLRequestMessageConsumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        JsonDeserializer<MLRequestMessage> deserializer = new JsonDeserializer<>(MLRequestMessage.class);
+        deserializer.setRemoveTypeHeaders(false);
+        deserializer.addTrustedPackages("*");
+        deserializer.setUseTypeMapperForKey(true);
+        //deserializer.addTrustedPackages("com.example.entity.Foo") // Adding Foo to our trusted packages
+
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, offsetReset);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, deserializer);
+        return new DefaultKafkaConsumerFactory<>(
+                props,
+                new StringDeserializer(),
+                deserializer);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, MLRequestMessage> MLRequestMessageListener() {
+        ConcurrentKafkaListenerContainerFactory<String, MLRequestMessage> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(MLRequestMessageConsumerFactory());
+        return factory;
+    }
+}

--- a/src/main/java/com/allknu/backend/core/types/SubscribeType.java
+++ b/src/main/java/com/allknu/backend/core/types/SubscribeType.java
@@ -1,6 +1,7 @@
 package com.allknu.backend.core.types;
 
 public enum SubscribeType {
+    EXCEPTION, //예외
     //부서
     COUNSEL, // 마음나눔센터
     CTL, // 교수학습지원센터

--- a/src/main/java/com/allknu/backend/kafka/MessageConsumer.java
+++ b/src/main/java/com/allknu/backend/kafka/MessageConsumer.java
@@ -1,16 +1,32 @@
 package com.allknu.backend.kafka;
 
 
+import com.allknu.backend.kafka.dto.FCMWebMessage;
+import com.allknu.backend.kafka.dto.MLRequestMessage;
+import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.handler.annotation.Headers;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 
 @Service
+@RequiredArgsConstructor
 public class MessageConsumer {
+    private final MessageProducer producer;
 
-    //@KafkaListener(topics = "exam", groupId = "foo")
-    //public void consume(String message) throws IOException {
-    //    System.out.println(String.format("Consumed message : %s", message));
-    //}
+    @KafkaListener(topics = "mlRequest", groupId = "all-knu-backend", containerFactory = "MLRequestMessageListener")
+    public void consume(@Payload MLRequestMessage message, @Headers MessageHeaders headers) throws IOException {
+        System.out.println(String.format("Consumed message : %s", message.getTitle()));
+        FCMWebMessage fcmWebMessage = FCMWebMessage.builder()
+                .title(message.getTitle())
+                .clickLink(message.getClickLink())
+                .body("비교과 프로그램 안내")
+                .subscribeTypes(message.getSubscribeTypes())
+                .build();
+
+        producer.sendFCMMessage(fcmWebMessage);
+    }
 }

--- a/src/main/java/com/allknu/backend/kafka/dto/MLRequestMessage.java
+++ b/src/main/java/com/allknu/backend/kafka/dto/MLRequestMessage.java
@@ -1,0 +1,22 @@
+package com.allknu.backend.kafka.dto;
+
+import com.allknu.backend.core.types.SubscribeType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MLRequestMessage {
+    private List<SubscribeType> subscribeTypes; //보내고자하는 구독 유형 리스트
+    private Integer predict;
+    private String title;
+    //바디가 없네..?
+    private String clickLink;
+    private String time;
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -19,3 +19,6 @@ spring:
 
   kafka:
     bootstrap-servers: kafka:9092
+    consumer:
+      group-id: all-knu-backend
+      auto-offset-reset: earliest

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,3 +19,6 @@ spring:
 
   kafka:
     bootstrap-servers: localhost:9092
+    consumer:
+      group-id: all-knu-backend
+      auto-offset-reset: earliest

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -19,3 +19,6 @@ spring:
 
   kafka:
     bootstrap-servers: 13.124.108.212:9092
+    consumer:
+      group-id: all-knu-backend
+      auto-offset-reset: earliest


### PR DESCRIPTION
## 구현내용
플라스크로부터 온 fcm 요청 kafka 메시지 처리 위한 컨슈머 구현
mlRequest 토픽 컨슈머를 구현해서 메시지를 꺼내 fcm 토픽으로 푸시 알림 요청한다.

### 학습 내용(optional)
어떤 기술써서 어떻게 했다. 에 대한 기술 설명

