### PR TITLE
공지사항 조회 API 호출 경로 변경

### DIFF
--- a/src/main/java/com/allknu/backend/web/CrawlingController.java
+++ b/src/main/java/com/allknu/backend/web/CrawlingController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,9 +24,17 @@ public class CrawlingController {
     private final CrawlingService crawlingService;
     private final KnuMobileApiService knuMobileApiService;
 
-    @GetMapping("/crawling/notice/univ/{page}") // 학교 공지사항 크롤링 요청
-    public ResponseEntity<CommonResponse> getUnivNotice(@PathVariable int page, @RequestParam(value = "type", required = false, defaultValue = "ALL") UnivNoticeType type) {
-        List<ResponseCrawling.UnivNotice> notices = crawlingService.getUnivNotice(page, type).orElseGet(() -> null);
+    @GetMapping(value = {"/crawling/notice/univ/{type}/{page}", "/crawling/notice/univ/{type}"}) // 학교 공지사항 크롤링 요청
+    public ResponseEntity<CommonResponse> getUnivNotice(@PathVariable String type, @PathVariable(required = false) Optional<Integer> page) {
+
+        UnivNoticeType realType = null;
+        try {
+            realType = UnivNoticeType.valueOf(type);
+        } catch (IllegalArgumentException e) {
+            realType = UnivNoticeType.ALL;
+        }
+
+        List<ResponseCrawling.UnivNotice> notices = crawlingService.getUnivNotice(page.orElseGet(()->1), realType).orElseGet(() -> null);
 
         CommonResponse response = CommonResponse.builder()
                 .status(HttpStatus.OK.value())


### PR DESCRIPTION
## 구현내용

### 학습 내용(optional)
어떤 기술써서 어떻게 했다. 에 대한 기술 설명

GET /crawling/notice/univ/{page}?type=[ALL, SCHOLARSHIP...]
--> GET /crawling/notice/univ/{type}/{page}

type
ALL("전체", 0),
ACADEMIC("학사", 116),
SCHOLARSHIP("장학", 117),
LEARNING("학습/상담", 118),
EMPLOY("취창업", 344);

API 호출 예시
전체 공지사항 1페이지 조회: GET /crawling/notice/univ/ALL/1
장학 공지사항 1페이지 조회: GET /crawling/notice/SCHOLARSHIP/1