### PR TITLE
[Refactor] Downloader, Scraper 인터페이스를 통해 크롤링 로직 수정 및 EventNotice 메서드 리팩토링/#102

### DIFF
--- a/src/main/java/com/allknu/backend/global/downloader/CrawlingDownloader.java
+++ b/src/main/java/com/allknu/backend/global/downloader/CrawlingDownloader.java
@@ -1,0 +1,13 @@
+package com.allknu.backend.global.downloader;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+
+import java.io.IOException;
+
+public class CrawlingDownloader implements Downloader{
+    @Override
+    public Document download(String url) throws IOException {
+        return Jsoup.connect(url).get();
+    }
+}

--- a/src/main/java/com/allknu/backend/global/downloader/Downloader.java
+++ b/src/main/java/com/allknu/backend/global/downloader/Downloader.java
@@ -1,0 +1,10 @@
+package com.allknu.backend.global.downloader;
+
+import org.jsoup.nodes.Document;
+
+import java.io.IOException;
+
+public interface Downloader {
+
+    Document download(String url) throws IOException;
+}

--- a/src/main/java/com/allknu/backend/global/scraper/Scraper.java
+++ b/src/main/java/com/allknu/backend/global/scraper/Scraper.java
@@ -1,0 +1,9 @@
+package com.allknu.backend.global.scraper;
+
+import org.jsoup.nodes.Document;
+
+import java.util.List;
+
+public interface Scraper<T> {
+    T scrape(Document document) throws Exception;
+}

--- a/src/main/java/com/allknu/backend/knuapi/application/CrawlingService.java
+++ b/src/main/java/com/allknu/backend/knuapi/application/CrawlingService.java
@@ -5,14 +5,16 @@ import com.allknu.backend.knuapi.domain.EventNoticeType;
 import com.allknu.backend.knuapi.domain.MajorNoticeType;
 import com.allknu.backend.knuapi.domain.UnivNoticeType;
 import com.allknu.backend.knuapi.application.dto.ResponseCrawling;
+import com.allknu.backend.knuapi.domain.scraper.dto.EventNoticeResponseDto;
+import com.allknu.backend.knuapi.domain.scraper.dto.UnivNoticeResponseDto;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface CrawlingService {
-    Optional<List<ResponseCrawling.UnivNotice>> getUnivNotice(int pageNum, UnivNoticeType type);
+    UnivNoticeResponseDto getUnivNotice(int pageNum, UnivNoticeType type);
     Optional<List<ResponseCrawling.UnivNotice>> getMajorDefaultTemplateNotice(int pageNum, MajorNoticeType type);
     CalendarResponseDto getKnuCalendar();
-    Optional<List<ResponseCrawling.EventNotice>> getEventNotice(int pageNum, EventNoticeType type);
+    EventNoticeResponseDto getEventNotice(int pageNum, EventNoticeType type);
 
 }

--- a/src/main/java/com/allknu/backend/knuapi/application/dto/ResponseCrawling.java
+++ b/src/main/java/com/allknu/backend/knuapi/application/dto/ResponseCrawling.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 public class ResponseCrawling {
     @Builder
     @Data
@@ -19,11 +21,20 @@ public class ResponseCrawling {
         private String views;
         private String number;
     }
+
     @Builder
     @Data
     @NoArgsConstructor
     @AllArgsConstructor
     public static class EventNotice {
+        private List<EventDetail> eventDetails;
+    }
+
+    @Builder
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class EventDetail {
         private String title;
         private String link;
         private String writer;

--- a/src/main/java/com/allknu/backend/knuapi/domain/scraper/EventNoticeScraper.java
+++ b/src/main/java/com/allknu/backend/knuapi/domain/scraper/EventNoticeScraper.java
@@ -1,0 +1,86 @@
+package com.allknu.backend.knuapi.domain.scraper;
+
+import com.allknu.backend.global.asset.ApiEndpointSecretProperties;
+import com.allknu.backend.global.scraper.Scraper;
+import com.allknu.backend.knuapi.domain.scraper.dto.EventNoticeResponseDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.*;
+
+
+@RequiredArgsConstructor
+public class EventNoticeScraper implements Scraper<EventNoticeResponseDto> {
+    private final ObjectMapper objectMapper;
+    private final ApiEndpointSecretProperties apiEndpointSecretProperties;
+    private static final Logger log = LoggerFactory.getLogger(EventNoticeScraper.class);
+
+    @Override
+    public EventNoticeResponseDto scrape(Document document) throws Exception {
+        Map<String, List<EventNoticeResponseDto.EventDetail>> eventNoticeMap = new LinkedHashMap<>();
+
+        Iterator<Element> rows = document.select("div.tbody > ul > li").iterator();
+        if (!rows.hasNext()) {
+            throw new Exception("조회 결과가 없습니다.");
+        }
+
+        while (rows.hasNext()) {
+            Element target = rows.next();
+            if ("NO_RESULT".equals(target.attr("class"))) { // 페이지에 조회 자료가 없는 경우
+                continue;
+            }
+            Elements dl = target.select("div > dl"); // li 안에 div 안에 dl들
+            Elements dt = dl.select("dt"); // title
+            Elements span = dl.select("dd > span"); // 작성자, 등록일, 조회수
+
+            String title = dt.get(0).text(); // 제목 title
+
+            // JSON 파싱 로직 필요
+            Element linkElement = dt.get(0).selectFirst("a.detailLink"); // 링크
+            String encMenuSeq, encMenuBoardSeq;
+            try {
+                JsonNode jsonNode = objectMapper.readTree(linkElement.attr("data-params"));
+                encMenuSeq = jsonNode.get("encMenuSeq").asText();
+                encMenuBoardSeq = jsonNode.get("encMenuBoardSeq").asText();
+            } catch (JsonProcessingException e) {
+                log.error("JSON 파싱 에러: ", e);
+                throw new Exception("JSON 파싱 에러: " + e.getMessage());
+            }
+
+            String link = apiEndpointSecretProperties.getCrawling().getEventNoticeItem()
+                    + "?scrtWrtiYn=false&encMenuSeq="
+                    + encMenuSeq
+                    + "&encMenuBoardSeq="
+                    + encMenuBoardSeq;
+
+            String writer = span.get(0).text().substring(3); // 작성자
+            String date = span.get(1).text().substring(4); // date
+            String views = span.get(2).text().substring(4); // views
+
+            EventNoticeResponseDto.EventDetail eventDetail = EventNoticeResponseDto.EventDetail.builder()
+                    .link(link)
+                    .date(date)
+                    .writer(writer)
+                    .views(views)
+                    .title(title)
+                    .build();
+
+            // 행사공지를 구분하는 키를 생성합니다.
+            // 예를 들어, 페이지 번호나 이벤트 타입을 사용할 수 있습니다.
+            String key = " ";
+
+            if (!eventNoticeMap.containsKey(key)) {
+                eventNoticeMap.put(key, new ArrayList<>());
+            }
+            eventNoticeMap.get(key).add(eventDetail);
+        }
+
+        return new EventNoticeResponseDto(eventNoticeMap);
+    }
+}

--- a/src/main/java/com/allknu/backend/knuapi/domain/scraper/UnivNoticeScraper.java
+++ b/src/main/java/com/allknu/backend/knuapi/domain/scraper/UnivNoticeScraper.java
@@ -1,0 +1,83 @@
+package com.allknu.backend.knuapi.domain.scraper;
+
+import com.allknu.backend.global.asset.ApiEndpointSecretProperties;
+import com.allknu.backend.global.scraper.Scraper;
+import com.allknu.backend.knuapi.domain.scraper.dto.UnivNoticeResponseDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.jsoup.internal.StringUtil;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.*;
+
+
+@RequiredArgsConstructor
+public class UnivNoticeScraper implements Scraper<UnivNoticeResponseDto> {
+    private final ObjectMapper objectMapper;
+    private final ApiEndpointSecretProperties apiEndpointSecretProperties;
+    private static final Logger log = LoggerFactory.getLogger(UnivNoticeScraper.class);
+
+    @Override
+    public UnivNoticeResponseDto scrape(Document document) throws Exception {
+        Map<String, List<UnivNoticeResponseDto.UnivNoticeDto>> univNoticeMap = new LinkedHashMap<>();
+
+        Iterator<Element> rows = document.select("div.tbody > ul").iterator();
+        if (!rows.hasNext()) {
+            throw new Exception("조회 결과가 없습니다.");
+        }
+
+        while (rows.hasNext()) {
+            Element target = rows.next();
+            Elements li = target.select("li"); // ul 안의 li들
+
+            String number = li.get(0).text(); // 게시글번호 li
+            if (!StringUtil.isNumeric(number)) {
+                //넘버가 숫자가 아니라면 필독공지임 이거는 패스
+                continue;
+            }
+
+            Element linkElement = li.get(1).selectFirst("a.detailLink"); // 링크li
+            String encMenuSeq, encMenuBoardSeq;
+            try {
+                JsonNode jsonNode = objectMapper.readTree(linkElement.attr("data-params"));
+                encMenuSeq = jsonNode.get("encMenuSeq").asText();
+                encMenuBoardSeq = jsonNode.get("encMenuBoardSeq").asText();
+            } catch (JsonProcessingException e) {
+                log.error("JSON 파싱 에러: ", e);
+                throw new Exception("JSON 파싱 에러: " + e.getMessage());
+            }
+
+            String link = apiEndpointSecretProperties.getCrawling().getUnivNoticeItem() + "?scrtWrtiYn=false&encMenuSeq="
+                    + encMenuSeq + "&encMenuBoardSeq=" + encMenuBoardSeq;
+
+            String title = linkElement.text();
+            String writeType = li.get(2).text(); //구분 li
+            String writer = li.get(4).text(); // 작성자
+            String date = li.get(5).text(); // date
+            String views = li.get(6).text(); // views
+
+            UnivNoticeResponseDto.UnivNoticeDto notice = UnivNoticeResponseDto.UnivNoticeDto.builder()
+                    .link(link)
+                    .date(date)
+                    .number(number)
+                    .writer(writer)
+                    .type(writeType)
+                    .views(views)
+                    .title(title)
+                    .build();
+
+            if (!univNoticeMap.containsKey(writeType)) {
+                univNoticeMap.put(writeType, new ArrayList<>());
+            }
+            univNoticeMap.get(writeType).add(notice);
+        }
+
+        return new UnivNoticeResponseDto(univNoticeMap);
+    }
+}
+

--- a/src/main/java/com/allknu/backend/knuapi/domain/scraper/dto/EventNoticeResponseDto.java
+++ b/src/main/java/com/allknu/backend/knuapi/domain/scraper/dto/EventNoticeResponseDto.java
@@ -1,0 +1,26 @@
+package com.allknu.backend.knuapi.domain.scraper.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+public class EventNoticeResponseDto {
+
+    private Map<String, List<EventDetail>> eventNoticeMap;
+
+
+    @Getter
+    @Builder
+    public static class EventDetail{
+        private String link;
+        private String date;
+        private String writer;
+        private String views;
+        private String title;
+    }
+}

--- a/src/main/java/com/allknu/backend/knuapi/domain/scraper/dto/UnivNoticeResponseDto.java
+++ b/src/main/java/com/allknu/backend/knuapi/domain/scraper/dto/UnivNoticeResponseDto.java
@@ -1,0 +1,28 @@
+package com.allknu.backend.knuapi.domain.scraper.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+public class UnivNoticeResponseDto {
+
+    private Map<String, List<UnivNoticeDto>> univNoticeMap;
+
+    @Getter
+    @Builder
+    public static class UnivNoticeDto {
+        private String title;
+        private String link;
+        private String type;
+        private String writer;
+        private String date;
+        private String views;
+        private String number;
+    }
+}

--- a/src/main/java/com/allknu/backend/knuapi/presentation/CrawlingController.java
+++ b/src/main/java/com/allknu/backend/knuapi/presentation/CrawlingController.java
@@ -10,6 +10,8 @@ import com.allknu.backend.knuapi.domain.UnivNoticeType;
 import com.allknu.backend.global.dto.CommonResponse;
 import com.allknu.backend.knuapi.application.dto.ResponseCrawling;
 import com.allknu.backend.knuapi.application.dto.ResponseKnu;
+import com.allknu.backend.knuapi.domain.scraper.dto.EventNoticeResponseDto;
+import com.allknu.backend.knuapi.domain.scraper.dto.UnivNoticeResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,7 +28,10 @@ public class CrawlingController {
     private final CrawlingService crawlingService;
     private final KnuMobileApiService knuMobileApiService;
 
-    @GetMapping(value = {"/crawling/notice/univ/{type}/{page}", "/crawling/notice/univ/{type}"}) // 학교 공지사항 크롤링 요청
+
+
+    @GetMapping(value = {"/crawling/notice/univ/{type}/{page}", "/crawling/notice/univ/{type}"})
+    // 학교 공지사항 크롤링 요청
     public ResponseEntity<CommonResponse> getUnivNotice(@PathVariable String type, @PathVariable(required = false) Optional<Integer> page) {
 
         UnivNoticeType realType = null;
@@ -36,33 +41,33 @@ public class CrawlingController {
             realType = UnivNoticeType.ALL;
         }
 
-        List<ResponseCrawling.UnivNotice> notices = crawlingService.getUnivNotice(page.orElseGet(()->1), realType).orElseGet(() -> null);
+        UnivNoticeResponseDto univNotice = crawlingService.getUnivNotice(page.orElseGet(()->1), realType);
 
         return new ResponseEntity<>(CommonResponse.builder()
                 .status(HttpStatus.OK.value())
                 .message("성공")
-                .list(notices)
+                .list(univNotice.getUnivNoticeMap())  // UnivNoticeResponseDto 객체에서 Map 객체를 가져옵니다.
                 .build(), HttpStatus.OK);
     }
     @GetMapping(value = {"/crawling/notice/event/{type}/{page}", "/crawling/notice/event/{type}"})
-    // 학교 공지사항 크롤링 요청
     public ResponseEntity<CommonResponse> getEventNotice(@PathVariable String type, @PathVariable(required = false) Optional<Integer> page) {
+        // 학교 공지사항 크롤링
         EventNoticeType realType = null;
         try {
             realType = EventNoticeType.valueOf(type);
         } catch (IllegalArgumentException e) {
             realType = EventNoticeType.ALL;
         }
-        List<ResponseCrawling.EventNotice> eventNotice = crawlingService.getEventNotice(page.orElseGet(() -> 1), realType).orElseGet(() -> null);
+        EventNoticeResponseDto eventNotice = crawlingService.getEventNotice(page.orElseGet(() -> 1), realType);
 
         return new ResponseEntity<>(CommonResponse.builder()
                 .status(HttpStatus.OK.value())
                 .message("성공")
-                .list(eventNotice)
+                .list(eventNotice.getEventNoticeMap())  // EventNoticeResponseDto 객체에서 Map 객체를 가져옵니다.
                 .build(), HttpStatus.OK);
-
     }
-    
+
+
     @GetMapping("/crawling/notice/major")
     public ResponseEntity<CommonResponse> getMajorNotice(@RequestParam(required = false, defaultValue = "1") int page, @RequestParam(value = "type", required = true, defaultValue = "SOFTWARE") MajorNoticeType type) {
         //기본 강남대 템플릿을 사용하는 학과 공지사항을 크롤링해 반환한다. 만약 기본 템플릿을 사용하지 않는 학과가 생긴다면 switch로 학과에 따라 분기해 긁어오는 코드를 작성할 것
@@ -99,4 +104,5 @@ public class CrawlingController {
                 .list(response.getCalendarMap())
                 .build(),HttpStatus.OK);
     }
+
 }

--- a/src/test/java/com/allknu/backend/knuapi/application/CrawlingServiceTests.java
+++ b/src/test/java/com/allknu/backend/knuapi/application/CrawlingServiceTests.java
@@ -6,6 +6,8 @@ import com.allknu.backend.knuapi.domain.EventNoticeType;
 import com.allknu.backend.knuapi.domain.MajorNoticeType;
 import com.allknu.backend.knuapi.domain.UnivNoticeType;
 import com.allknu.backend.knuapi.application.dto.ResponseCrawling;
+import com.allknu.backend.knuapi.domain.scraper.dto.EventNoticeResponseDto;
+import com.allknu.backend.knuapi.domain.scraper.dto.UnivNoticeResponseDto;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +17,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -28,23 +31,29 @@ public class CrawlingServiceTests {
     @Test
     @DisplayName("공지사항 크롤링 테스트")
     void getUnivNoticeTest() {
-        List<ResponseCrawling.UnivNotice> notices = crawlingService.getUnivNotice(1, UnivNoticeType.ALL).orElseGet(()->null);
-        for(int i = 0 ; i < notices.size() ; i++) {
-            ResponseCrawling.UnivNotice notice = notices.get(i);
-            System.out.println(notice.getTitle() + notice.getDate() + notice.getViews() + notice.getLink());
+        UnivNoticeResponseDto univNotice = crawlingService.getUnivNotice(1, UnivNoticeType.ALL);
+
+        for (Map.Entry<String, List<UnivNoticeResponseDto.UnivNoticeDto>> entry : univNotice.getUnivNoticeMap().entrySet()) {
+            for (UnivNoticeResponseDto.UnivNoticeDto notice : entry.getValue()) {
+                System.out.println(notice.getTitle() + notice.getDate() + notice.getViews() + notice.getLink());
+            }
         }
+
+        Assertions.assertNotEquals(0, univNotice.getUnivNoticeMap().size());
     }
     @Test
     @DisplayName("행사/안내 크롤링 테스트")
     void getEventNoticeTest() {
-        List<ResponseCrawling.EventNotice> eventNotice = crawlingService.getEventNotice(1, EventNoticeType.ALL).orElseGet(()->null);
-        for(int i = 0 ; i < eventNotice.size() ; i++) {
-            ResponseCrawling.EventNotice eventNoticeResult = eventNotice.get(i);
-            System.out.println(eventNoticeResult.getTitle()+ "\n" + eventNoticeResult.getDate() + "\n" + eventNoticeResult.getViews() + "\n" + eventNoticeResult.getLink()
-                    + "\n" + eventNoticeResult.getWriter());
-        }
-    }
+        EventNoticeResponseDto eventNotice = crawlingService.getEventNotice(1, EventNoticeType.ALL);
 
+        for (Map.Entry<String, List<EventNoticeResponseDto.EventDetail>> entry : eventNotice.getEventNoticeMap().entrySet()) {
+            for (EventNoticeResponseDto.EventDetail notice : entry.getValue()) {
+                System.out.println(notice.getTitle() + "\n" + notice.getDate() + "\n" + notice.getViews() + "\n" + notice.getLink() + "\n" + notice.getWriter());
+            }
+        }
+
+        Assertions.assertNotEquals(0, eventNotice.getEventNoticeMap().size());
+    }
     @Test
     @DisplayName("기본 강남대 템플릿을 사용하는 학과 공지사항 크롤링 테스트")
     void getMajorNoticeTest() {


### PR DESCRIPTION
## 구현내용
CrawlingServiceImpl -> getEvenetNotice method refactoring
- getEventNotice 메서드 리턴 타입 변경(Optional -> 빈 컬렉션 반환)
- getEventNotice url 연산시 + 연산자 대신 StringBuilder로 수정

Crawling logic refactoring
- 기존 crwalingservice에서 공통적으로 사용되는 웹 페이지 다운로드(downloader), 필요한 정보를 추출(scraper)r 기능을 인터페이스로 분리해 확장성있게 구현. 
- Downloader : 다운로드할 인자를 url로 받아 결과를 반환. 
- Scraper : 다운로드 페이지에서 필요한 정보를 추출해 결과를 반환.

### 학습 내용(optional)

1. Optional -> 빈 컬렉션 
- optional의 주 기능은 null을 반환할 수 있다는 것을 명시하는 역할. 
- 그러나 getEventNotice의 경우엔 list(list,map,set등 컬렉션은 자체적으로 값이 없음을 표현 가능, null == 빈 컬렉션 반환) 를 반환하기 때문에 NPE방지, 클라이언트 측에서 가독성(null 체크), 복잡성(새로운 컬렉션을 생성하는 코드등)등 효율성 측면에서 코드 수정. 

2. String -> StringBuilder
- StringBuilder의 주 기능은 연산마다 새로운 객체를 생성하지 않고, 기존 버퍼에 추가하는 방식. 
- 문자열을 추가, 변경시 기존 코드를 복사하지 않기 때문에 성능적으로 향상. 
- ++ Stringbuilder는 스레드 안전하지 않기 때문에 멀티스레드일 경우엔 StringBuffer를 사용. 
- ++ 다만 StringBuffer의 경우엔 동시접근시에도 일관성을 유지하는 장점을 가지지만, 동기화 과정에서 큰 비용이 발생. 
- ++ 그렇기 때문에 단일스레드일 경우엔 StringBuilder, 멀티 스레드일 경우엔 StringBuffer를 사용.
- 이후 코드를 추가하면서 java5이후, + 연산자 또한 컴파일시 StringBuilder로 변환된다는 것을 알고, String으로 코드 재수정. 

Downloader
- Jsoup 로직 이용해 다운로드 인자를 Url로 받아 결과를 반환. 

Scraper 
- 다운로드 페이지에서 필요한 정보를 추출해 결과를 반환. 
- EventNoticeScraper 구현시, 기존 스크래핑 코드를 가져오면서 "Method 'scrape' is inherited. Do you want to add exceptions to method signatures in the whole method hierarchy?"란 예외를 처음 보게 되었고, 메서드 오버라이딩 경우에 하위 계층의 예외처리 추가가 상위 계층의 상속 계층 구조의 모든 구조에 예외처리를 추가하게 되어, 코드 호환성 문제를 발생시킨다는 경고. try-catch 구문과 로그를 이용해 기존 예외 처리. 

=> 인터페이스 사용 장점 : 역할을 명확하게 함으로서 가독성 높임, 새로운 기능이 추가되도, 스크랩터 클래스를 추가함으로서 확장성 또한 높임. 

