### PR TITLE
fix: 식당 생성시 식당 이름에 null, 공백이 들어가는 버그 수정

### DIFF
--- a/src/main/java/com/allknu/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/allknu/backend/global/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     KNU_API_FAILED(HttpStatus.FORBIDDEN, "AUTH_005", "knu api call failed"),
     RESTAURANT_NAME_DUPLICATED(HttpStatus.FORBIDDEN, "RESTAURANT_001", "식당 이름 중복됨"),
     NOT_FOUND_RESTAURANT(HttpStatus.NOT_FOUND, "RESTAURANT_002", "식당이 존재하지 않음"),
+    INVALID_RESTAURANT_NAME(HttpStatus.BAD_REQUEST, "RESTAURANT_003", "식당 이름은 공백이 될 수 없습니다."),
     NOT_FOUND_MENU(HttpStatus.NOT_FOUND, "MENU_001", "식당, 날짜, 타입이 같은 메뉴가 존재하지 않음"),
     STATION_NAME_DUPLICATED(HttpStatus.FORBIDDEN, "SHUTTLE_001", "정거장 이름 중복됨"),
     NOT_FOUND_STATION(HttpStatus.NOT_FOUND,"SHUTTLE_002","정거장이 없음."),

--- a/src/main/java/com/allknu/backend/global/exception/errors/InvalidRestaurantNameException.java
+++ b/src/main/java/com/allknu/backend/global/exception/errors/InvalidRestaurantNameException.java
@@ -1,0 +1,12 @@
+package com.allknu.backend.global.exception.errors;
+
+import com.allknu.backend.global.exception.ErrorCode;
+
+public class InvalidRestaurantNameException extends RuntimeException{
+    public InvalidRestaurantNameException() {
+        super(ErrorCode.INVALID_RESTAURANT_NAME.getMessage());
+    }
+    public InvalidRestaurantNameException(Exception ex) {
+        super(ex);
+    }
+}

--- a/src/main/java/com/allknu/backend/restaurant/domain/RestaurantRepository.java
+++ b/src/main/java/com/allknu/backend/restaurant/domain/RestaurantRepository.java
@@ -3,7 +3,10 @@ package com.allknu.backend.restaurant.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
-    Restaurant findByRestaurantName(String restaurantName);
+    Optional<Restaurant> findByRestaurantName(String restaurantName);
+
 }

--- a/src/test/java/com/allknu/backend/restaurant/application/RestaurantServiceTests.java
+++ b/src/test/java/com/allknu/backend/restaurant/application/RestaurantServiceTests.java
@@ -1,5 +1,6 @@
 package com.allknu.backend.restaurant.application;
 
+import com.allknu.backend.global.exception.errors.InvalidRestaurantNameException;
 import com.allknu.backend.restaurant.application.RestaurantService;
 import com.allknu.backend.restaurant.domain.MealType;
 import com.allknu.backend.restaurant.domain.Menu;
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -35,10 +37,10 @@ public class RestaurantServiceTests {
     @DisplayName("식당 추가 서비스 테스트")
     void registerRestaurantTest() {
         restaurantService.registerRestaurant("샬롬관 학식당");    //식당 저장
-        Restaurant res = restaurantRepository.findByRestaurantName("샬롬관 학식당");
-        assertNotNull(res);
-        System.out.println(res.getRestaurantName());
-        }
+        Optional<Restaurant> res = restaurantRepository.findByRestaurantName("샬롬관 학식당");
+        assertTrue(res.isPresent());
+        System.out.println(res.get().getRestaurantName());
+    }
     @Test
     @Transactional
     @DisplayName("식당 추가 중복 오류 테스트")
@@ -47,6 +49,25 @@ public class RestaurantServiceTests {
         assertThrows(RestaurantNameDuplicatedException.class, () ->   //식당 중복 예외가 발생하면 테스트 성공
             restaurantService.registerRestaurant("샬롬관 학식당"));
     }
+    @Test
+    @Transactional
+    @DisplayName("식당 이름이 null인 경우 테스트")
+    void registerRestaurantNullTest() {
+        Exception exception = assertThrows(InvalidRestaurantNameException.class, () ->
+                restaurantService.registerRestaurant(null));
+        System.out.println(exception.getMessage());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("식당 이름이 공백인 경우 테스트")
+    void registerRestaurantEmptyTest() {
+        Exception exception = assertThrows(InvalidRestaurantNameException.class, () ->
+                restaurantService.registerRestaurant(" "));
+        System.out.println(exception.getMessage());
+    }
+
+
 
     @Test
     @Transactional

--- a/src/test/java/com/allknu/backend/restaurant/domain/RestaurantRepositoryTests.java
+++ b/src/test/java/com/allknu/backend/restaurant/domain/RestaurantRepositoryTests.java
@@ -13,8 +13,10 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -33,9 +35,9 @@ public class RestaurantRepositoryTests {
                         .build();
                 restaurant = restaurantRepository.save(restaurant);
 
-                Restaurant restaurantAdd = restaurantRepository.findByRestaurantName(restaurant.getRestaurantName());
-                assertNotNull(restaurantAdd);
-                System.out.println(restaurantAdd.getRestaurantName());
+                Optional<Restaurant> restaurantAdd = restaurantRepository.findByRestaurantName(restaurant.getRestaurantName());
+                assertTrue(restaurantAdd.isPresent());
+                System.out.println(restaurantAdd.get().getRestaurantName());
         }
         @Transactional
         @DisplayName("메뉴 추가 테스트")


### PR DESCRIPTION
## 구현내용
식당 생성시 식당 이름에 null, 공백값만 들어오는 경우에 예외처리 하도록 코드 구현. 

### 학습 내용(optional)
식당 이름에 Null이 들어오거나, 공백이 들어올 경우 trim메소드를 통해 앞 뒤 공백을 제거해 null값이 나온다면 예외처리하도록 코드 구현 . 
해당 코드를 확인하기 위해 테스트 코드를 추가해 null값이 들어온 경우, " " 공백이 들어온 경우를 테스트해 코드 작동되는지 확인. 

