### PR TITLE
feature : #94 all-knu-backend 레포지토리 스프링 부트 3.x 업그레이드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.5.4'
+    id 'org.springframework.boot' version '3.2.1'
     id 'io.spring.dependency-management' version '1.1.0'
 }
 
@@ -11,7 +11,6 @@ repositories {
 group = 'com.allknu'
 version = '0.0.1-SNAPSHOT'
 description = 'backend'
-java.sourceCompatibility = JavaVersion.VERSION_11
 
 configurations {
     compileOnly {
@@ -29,13 +28,14 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux' // weblcient 대체 시 제거
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor" //
 
     annotationProcessor 'org.projectlombok:lombok'
     implementation 'org.jsoup:jsoup:1.17.2'
 
-    implementation 'org.flywaydb:flyway-core:7.5.1'
+    implementation 'org.flywaydb:flyway-core'
     implementation 'mysql:mysql-connector-java:8.0.26'
-    runtimeOnly 'com.h2database:h2:1.4.200'
+    runtimeOnly 'com.h2database:h2'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'

--- a/src/main/java/com/allknu/backend/auth/presentation/AuthController.java
+++ b/src/main/java/com/allknu/backend/auth/presentation/AuthController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/src/main/java/com/allknu/backend/fcmapi/application/dto/PushMobileRequestDto.java
+++ b/src/main/java/com/allknu/backend/fcmapi/application/dto/PushMobileRequestDto.java
@@ -9,7 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
 
 @Data

--- a/src/main/java/com/allknu/backend/fcmapi/application/dto/SubscribeRequestDto.java
+++ b/src/main/java/com/allknu/backend/fcmapi/application/dto/SubscribeRequestDto.java
@@ -6,8 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 @Data

--- a/src/main/java/com/allknu/backend/fcmapi/domain/FirebaseLog.java
+++ b/src/main/java/com/allknu/backend/fcmapi/domain/FirebaseLog.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.Date;
 
 @Table(name="fcm_log")

--- a/src/main/java/com/allknu/backend/fcmapi/presentation/FcmApiController.java
+++ b/src/main/java/com/allknu/backend/fcmapi/presentation/FcmApiController.java
@@ -16,8 +16,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.validation.Valid;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/com/allknu/backend/flyway/FlywayConfiguration.java
+++ b/src/main/java/com/allknu/backend/flyway/FlywayConfiguration.java
@@ -1,0 +1,26 @@
+package com.allknu.backend.flyway;
+
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import org.flywaydb.core.Flyway;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class FlywayConfiguration {
+
+    private final DataSource dataSource;
+    private final LocationResolver locationResolver;
+
+    @Bean(initMethod = "migrate")
+    public Flyway flyway() {
+        String location = "classpath:db/migration/{vendor}";
+        return Flyway.configure()
+                .dataSource(dataSource)
+                .locations(locationResolver.resolveLocation(location))
+                .baselineOnMigrate(true)
+                .load();
+    }
+
+}

--- a/src/main/java/com/allknu/backend/flyway/LocationResolver.java
+++ b/src/main/java/com/allknu/backend/flyway/LocationResolver.java
@@ -1,0 +1,50 @@
+package com.allknu.backend.flyway;
+
+import java.sql.DatabaseMetaData;
+import javax.sql.DataSource;
+import org.springframework.boot.jdbc.DatabaseDriver;
+import org.springframework.jdbc.support.JdbcUtils;
+import org.springframework.jdbc.support.MetaDataAccessException;
+import org.springframework.stereotype.Service;
+
+@Service
+class LocationResolver {
+
+    private static final String VENDOR_PLACEHOLDER = "{vendor}";
+    private final DataSource dataSource;
+
+    LocationResolver(DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    String resolveLocation(String location) {
+        if (this.usesVendorLocation(location)) {
+            DatabaseDriver databaseDriver = this.getDatabaseDriver();
+            return this.replaceVendorLocation(location, databaseDriver);
+        } else {
+            return location;
+        }
+    }
+
+    private String replaceVendorLocation(String location, DatabaseDriver databaseDriver) {
+        if (databaseDriver == DatabaseDriver.UNKNOWN) {
+            return location;
+        } else {
+            String vendor = databaseDriver.getId();
+            return location.replace(VENDOR_PLACEHOLDER, vendor);
+        }
+    }
+
+    private DatabaseDriver getDatabaseDriver() {
+        try {
+            String url = (String) JdbcUtils.extractDatabaseMetaData(this.dataSource, DatabaseMetaData::getURL);
+            return DatabaseDriver.fromJdbcUrl(url);
+        } catch (MetaDataAccessException var2) {
+            throw new IllegalStateException(var2);
+        }
+    }
+
+    private boolean usesVendorLocation(String location) {
+        return location.contains(VENDOR_PLACEHOLDER);
+    }
+}

--- a/src/main/java/com/allknu/backend/global/asset/ApiEndpointSecretProperties.java
+++ b/src/main/java/com/allknu/backend/global/asset/ApiEndpointSecretProperties.java
@@ -3,10 +3,8 @@ package com.allknu.backend.global.asset;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.ConstructorBinding;
 
 @Getter
-@ConstructorBinding
 @AllArgsConstructor
 @ConfigurationProperties(prefix = "api-endpoint")
 public class ApiEndpointSecretProperties {

--- a/src/main/java/com/allknu/backend/global/security/AuthTokenProvider.java
+++ b/src/main/java/com/allknu/backend/global/security/AuthTokenProvider.java
@@ -1,6 +1,6 @@
 package com.allknu.backend.global.security;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Date;
 import java.util.Optional;
 

--- a/src/main/java/com/allknu/backend/global/security/JwtAuthTokenProvider.java
+++ b/src/main/java/com/allknu/backend/global/security/JwtAuthTokenProvider.java
@@ -4,7 +4,7 @@ import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.util.StringUtils;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import java.security.Key;
 import java.util.Date;
 import java.util.Optional;

--- a/src/main/java/com/allknu/backend/global/security/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/allknu/backend/global/security/interceptor/AuthInterceptor.java
@@ -7,8 +7,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Optional;
 
 @RequiredArgsConstructor

--- a/src/main/java/com/allknu/backend/knuapi/application/dto/RequestKnu.java
+++ b/src/main/java/com/allknu/backend/knuapi/application/dto/RequestKnu.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 public class RequestKnu {
 

--- a/src/main/java/com/allknu/backend/knuapi/presentation/KnuApiController.java
+++ b/src/main/java/com/allknu/backend/knuapi/presentation/KnuApiController.java
@@ -12,7 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Map;
 

--- a/src/main/java/com/allknu/backend/map/application/dto/RequestMap.java
+++ b/src/main/java/com/allknu/backend/map/application/dto/RequestMap.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 public class RequestMap {
     @Builder

--- a/src/main/java/com/allknu/backend/map/domain/GPSLocation.java
+++ b/src/main/java/com/allknu/backend/map/domain/GPSLocation.java
@@ -4,8 +4,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Column;
-import javax.persistence.Embeddable;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
 
 // GPS 정보에 대한 임베디드 타입
 @Embeddable

--- a/src/main/java/com/allknu/backend/map/domain/MapMarker.java
+++ b/src/main/java/com/allknu/backend/map/domain/MapMarker.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 @Table(name="map_marker")
 @Entity

--- a/src/main/java/com/allknu/backend/map/domain/MapMarkerOperationInfo.java
+++ b/src/main/java/com/allknu/backend/map/domain/MapMarkerOperationInfo.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 
 /**
  * MapMarker 와 1대1 매핑이되는 운영시간 관련 추가 정보

--- a/src/main/java/com/allknu/backend/map/presentation/MapController.java
+++ b/src/main/java/com/allknu/backend/map/presentation/MapController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import java.util.List;
 
 @RestController

--- a/src/main/java/com/allknu/backend/restaurant/application/dto/RequestRestaurant.java
+++ b/src/main/java/com/allknu/backend/restaurant/application/dto/RequestRestaurant.java
@@ -7,7 +7,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 import java.util.Date;
 import java.util.List;

--- a/src/main/java/com/allknu/backend/restaurant/domain/Menu.java
+++ b/src/main/java/com/allknu/backend/restaurant/domain/Menu.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.Date;
 
 @Table(name="menu")

--- a/src/main/java/com/allknu/backend/restaurant/domain/Restaurant.java
+++ b/src/main/java/com/allknu/backend/restaurant/domain/Restaurant.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/allknu/backend/restaurant/presentation/RestaurantController.java
+++ b/src/main/java/com/allknu/backend/restaurant/presentation/RestaurantController.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import java.util.Date;
 
 @RestController

--- a/src/main/java/com/allknu/backend/shuttle/application/dto/RequestStationTimetable.java
+++ b/src/main/java/com/allknu/backend/shuttle/application/dto/RequestStationTimetable.java
@@ -2,7 +2,7 @@ package com.allknu.backend.shuttle.application.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
-import javax.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotNull;
 import java.util.Date;
 
 public class RequestStationTimetable {

--- a/src/main/java/com/allknu/backend/shuttle/domain/Station.java
+++ b/src/main/java/com/allknu/backend/shuttle/domain/Station.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/allknu/backend/shuttle/domain/StationTimetable.java
+++ b/src/main/java/com/allknu/backend/shuttle/domain/StationTimetable.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import jakarta.persistence.*;
 import java.util.Date;
 
 @Table(name = "station_timetable")

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -6,14 +6,12 @@ spring:
 
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:test
+    url: jdbc:h2:mem:test;mode=mysql
     username: sa
     password:
 
   flyway:
-    enabled: true
-    baselineOnMigrate: true
-    locations: classpath:db/migration/{vendor}
+    enabled: false
 
   jpa:
     show-sql: true
@@ -26,4 +24,4 @@ spring:
         format_sql: true
 
 external-client:
-  fcm: http://all-knu-fcm:8080
+  fcm: http://all-knu-fcm-develop:8080

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -6,24 +6,22 @@ spring:
 
   datasource:
     driver-class-name: org.h2.Driver
-    url: jdbc:h2:mem:test
+    url: jdbc:h2:mem:test;mode=mysql
     username: sa
     password:
 
   flyway:
-    enabled: true
-    baselineOnMigrate: true
-    locations: classpath:db/migration/{vendor}
+    enabled: false
 
   jpa:
     show-sql: true
     generate-ddl: false
     hibernate:
-      ddl-auto: validate
+      ddl-auto: create
 
     properties:
       hibernate:
         format_sql: true
 
 external-client:
-  fcm: http://all-knu-fcm:8080
+  fcm: http://all-knu-fcm-develop:8080

--- a/src/test/java/com/allknu/backend/map/application/MapServiceTest.java
+++ b/src/test/java/com/allknu/backend/map/application/MapServiceTest.java
@@ -14,13 +14,16 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @DataJpaTest
+@Transactional
 @ActiveProfiles("test")
 class MapServiceTest {
     @Autowired


### PR DESCRIPTION
## 구현내용
Springboot 2.xx -> 3.xx 버전 업.

### 학습 내용(optional)

버전 업그레이드 시 변경 상항 수정. 
- 의존성 변경 : javax -> jarkarta 

ConfigurationProperties 클래스에 대한 ConstructorBinding 애노테이션 사용 단순화.
Ex) Constructor 사용이 필요한 예시
- 프로퍼티 바인딩을 위한 생성자 지정시.
- 두 개 이상의 생성자가 있는 경우, 생성자 지정시.
- 생성자에 빈을 주입시 @Autowired 애노테이션 추가.

flyway 사용 X , h2 최신 버전 사용
- Spring boot 3.xx 업그레이드시 flyway 최신 버전(7.5.1)을 지원 x -> AutoFlywayConfiguration을 지원 x => 수동으로 클래스를 작성. 
Springboot 3.xx 업그레이드시 h2(1.4.200)의 버전의 경우, jarkarta 패키지를 갖고 오지 못함. -> 그래서 h2 최신 버전을 사용해 jarkarta 패키지를 갖고 오도록 작성. 

- 버전 업데이트간, flyway AutoFlywayConfiguration 클래스 작성과 h2 버전업을 시켜도 "Caused by: org.hibernate.tool.schema.spi.SchemaManagementException: Schema-validation: missing table [fcm_log]", "[PersistenceUnit: default] Unable to build Hibernate SessionFactory; nested exception is org.hibernate.tool.schema.spi.SchemaManagementException: Schema-validation: missing table [fcm_log]" 에러가 계속 발생. 

- 현재 yml의 경우에 in-memory 방식을 사용하고 있는데, 일관성 문제가 발생하는게 이상해 application-local.yml, application-test.yml의 ddl-auto: validate측에서 문제가 발생했을 것이라 생각. 

- 버전 업데이트간 작성했던 FlywayConfiguration.java 클래스 코드에서 location의 위치를 flyway 라이브러리를 활용해 수동으로 넣어주는 것으로 문제 해결.  

MapServiceTest간 LazyInitializationException 문제

- Transactional 어노테이션 사용해 영속성 컨텍스트 유지. 
- 기존 애노테이션 DataJpaTest -> SpringBootTest 변경 시도(사용 x)
- => 상세 : - LazyInitializationException 발생. == 엔티티 로딩 시점에 세션이 닫혀 있는 경우. 
  - Transactional 어노테이션 사용. -> 메서드 실행간 영속성 컨텍스트를 유지.
    - 해당 메서드 내의 DB작업을 모두 같은 트랙잭션 범위에서 실행. -> 테스트 종료후 트랙잭션이 자동으로 롤백 되기때문에, 데이터베이스 간에 상태간섭 또한 방지
  - fetch = FetchType.Eager 설정. -> 연관 엔티티를 즉시 로딩하도록 설정. 
- Q . 기존 코드를 건드리지 않고 버전만 변경했을뿐인데 이런 에러가 발생하는 이유?? => Hibernate와 같은 ORM 프레임워크에서는 성능 향상이나 버그 수정을 위해 지연 로딩이나 즉시 로딩의 동작 방식이 변경될 수 있기 때문에 에러가 발생할 수 있음. 
- Q. DataJpaTest VS SpringBootTest 
  - DataJpaTest : JPA 컴포넌트에 초점을 맞춘 테스트. 
    - JPA 관련 설정만 로드됨으로 JPA 관련 빈들만 테스트 컨텍스트에 등록됨. 
    - => 그렇기때문에 테스트 실행 시간이 빠름. 
    - ex) 특정 쿼리 테스트, 클래스 매핑, 계층 메서드 테스트
  - SpringBootTest : 전체 동작을 테스트 하기 위한 테스트
    - 모든 빈들이 테스트 컨텍스트에 등록됨으로 통합 테스트에 주로 사용됨. 
    - => 테스트 실행시간이 느림
    - ex) 컴포넌트 상호작용 테스트, 실제 운영환경과 유사한 환경 테스트, 전체적인 흐름 테스트.

- ddl-auto 설정을  validation -> create로 변경해 문제 해결(테스트 환경시에만) 
  - DataJpaTest : 기존의 테스트 범위에 집중. <-> SpringBootTest : JPA 관련 기능에 집중하는 것보단 모든 스프링 컨텍스트를 로드하기 때문에 더 넓은 범위의 통합 테스트 진행.
  - 그렇기에 실행시간에 있어서도, DataJpaTest를 사용하는 것이 효율적임. 
  - 따라서 @DataJpaTest -> @SpringBootTest 변경 대신, ddl-auto를 validation -> create로 변경해 테스트의 범위를 제한하고 실행시간을 단축시키는 이점을 그대로 가지고 옴. 
    - 다만 이 방법은 테스트 환경시에만 사용. 

참고 자료 : https://techblog.lycorp.co.jp/ko/how-to-migrate-to-spring-boot-3

참고 자료 : https://velog.io/@gmtmoney2357/%EC%8A%A4%ED%94%84%EB%A7%81-%EB%B6%80%ED%8A%B8-3.0%EC%97%90%EC%84%9C-h2-console-404-%EC%97%90%EB%9F%AC