### PR TITLE
fix: #94 Spring Boot 3.2 @ConfigurationProperties 바인딩 이슈 해결 및 로그 관리 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,11 +11,16 @@ repositories {
 group = 'com.allknu'
 version = '0.0.1-SNAPSHOT'
 description = 'backend'
+sourceCompatibility = '17'
 
 configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+}
+
+compileJava {
+    options.compilerArgs << '-parameters'
 }
 
 test {
@@ -28,7 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux' // weblcient 대체 시 제거
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor" //
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
     annotationProcessor 'org.projectlombok:lombok'
     implementation 'org.jsoup:jsoup:1.17.2'
@@ -40,4 +45,5 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,45 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <!-- 이 곳에 추가할 properties를 넣는다. -->
-    <property name="LOGS_ABSOLUTE_PATH" value="/var/log"/> <!-- docker run 시 볼륨 매핑해주기 -->
+    <!-- properties를 추가하는 곳 -->
+    <property name="LOGS_ABSOLUTE_PATH" value="/var/log"/>
 
-    <!-- appender(어디에 출력할 지)에서 콘솔에 출력되는 형식을 지정한다. -->
+    <!-- appender에서 콘솔에 출력되는 형식을 지정 -->
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <layout class="ch.qos.logback.classic.PatternLayout">
             <Pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][%thread] %-5level %logger{36} - %msg%n</Pattern>
         </layout>
     </appender>
 
-    <springProfile name="prod"><!-- profile prod 에서만 동작해서 파일에 기록하도록 -->
-        <!-- Info 레벨의 이름을 가진 로그를 저장할 방식을 지정한다. -->
+    <springProfile name="prod">
+        <!-- Info 레벨의 이름을 가진 로그를 저장할 방식을 지정 -->
         <appender name="INFO_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
-
-            <file>${LOGS_ABSOLUTE_PATH}/info.log</file> <!-- 파일을 저장할 경로를 정한다, 도커 사용 시 볼륨매핑 해주어야함 -->
+            <!-- 파일을 저장할 경로를 지정, 도커 사용 시 볼륨매핑 해주어야함 -->
+            <file>${LOGS_ABSOLUTE_PATH}/info.log</file>
             <!-- filters 종류 키워드로 확인 -->
-            <filter class="ch.qos.logback.classic.filter.LevelFilter"> <!-- 지정한 레벨과 같은 로그이벤트 필터링 수행 -->
+            <filter class="ch.qos.logback.classic.filter.LevelFilter">
                 <level>INFO</level>
-                <onMatch>ACCEPT</onMatch> <!-- 해당 레벨만 기록한다. -->
-                <onMismatch>DENY</onMismatch> <!-- 지정 레벨과 맞지 않으면 onMisMatch 에 지정에 따라 수행, DENY -> print 하지않음 -->
-            </filter> <!-- 레벨별 필터링이 필요없을 경우 filter class 관련된 부분을 삭제하면 됨-->
+                <onMatch>ACCEPT</onMatch>
+                <onMismatch>DENY</onMismatch>
+            </filter>
             <encoder>
-                <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][%thread] %-5level %logger{35} - %msg%n</pattern> <!-- 해당 패턴 네이밍으로 현재 로그가 기록됨 -->
+                <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][%thread] %-5level %logger{35} - %msg%n</pattern>
             </encoder>
             <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                <fileNamePattern>${LOGS_ABSOLUTE_PATH}/was-logs/info/info.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern> <!-- 해당 패턴 네이밍으로 이전 파일이 기록됨 -->
+                <fileNamePattern>${LOGS_ABSOLUTE_PATH}/was-logs/info/info.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
                 <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-                    <maxFileSize>100MB</maxFileSize> <!-- 한 파일의 최대 용량 -->
+                    <maxFileSize>100MB</maxFileSize>
                 </timeBasedFileNamingAndTriggeringPolicy>
-                <maxHistory>60</maxHistory> <!-- 한 파일의 최대 저장 기한 -->
-                <totalSizeCap>1GB</totalSizeCap> <!-- 전체 로그파일 크기 제한, 1기가 넘으면 오래된거 삭제 -->
+                <maxHistory>60</maxHistory>
+                <totalSizeCap>1GB</totalSizeCap>
             </rollingPolicy>
         </appender>
     </springProfile>
 
     <springProfile name="prod">
         <appender name="WARN_OR_MORE_LOG" class="ch.qos.logback.core.rolling.RollingFileAppender">
-
-            <file>${LOGS_ABSOLUTE_PATH}/warn-or-more.log</file>
-            <filter class="ch.qos.logback.classic.filter.ThresholdFilter"> <!-- 지정레벨 이상의 로그만 print 하는 필터 -->
+            <file>${LOGS_ABSOLUTE_PATHwarn-or-more.log</file>
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
                 <level>WARN</level>
             </filter>
             <encoder>
@@ -50,23 +49,21 @@
                 <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                     <maxFileSize>100MB</maxFileSize>
                 </timeBasedFileNamingAndTriggeringPolicy>
-                <maxHistory>60</maxHistory> <!-- 한 파일의 최대 저장 기한 -->
-                <totalSizeCap>1GB</totalSizeCap> <!-- 전체 로그파일 크기 제한, 1기가 넘으면 오래된거 삭제 -->
+                <maxHistory>60</maxHistory>
+                <totalSizeCap>1GB</totalSizeCap>
             </rollingPolicy>
         </appender>
     </springProfile>
 
     <!-- 루트로거 구성, 루트로그의 기본 수준을 INFO로 지정, info 이상만 print -->
     <root level="INFO">
-        <springProfile name="!prod">
-            <!-- 각 appender는 루트 로거에 추가 -->
-            <appender-ref ref="STDOUT"/>
-        </springProfile>
-        <springProfile name="prod">
-            <!-- 각 appender는 루트 로거에 추가 -->
-            <appender-ref ref="STDOUT"/>
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <springProfile name="prod">
+        <root level="INFO">
             <appender-ref ref="WARN_OR_MORE_LOG"/>
             <appender-ref ref="INFO_LOG"/>
-        </springProfile>
-    </root>
+        </root>
+    </springProfile>
 </configuration>


### PR DESCRIPTION
## 구현내용

#### 문제 상황

- Spring Boot 3.2.1에서 `@ConfigurationProperties`가 속성 값을 제대로 바인드하지 못하는 문제 발생
- 매개변수의 이름을 인식하지 못하고, 로그 관리 설정에서 문제 발생. 
- 에러 메시지:

```javascript
Failed to bind properties under 'token' to revi1337.configurationpropertiesdemo.property.TokenProperties:
Reason: java.lang.IllegalStateException: Unable to create instance for revi1337.configurationpropertiesdemo.property.TokenProperties
This may be due to missing parameter name information
Action: Update your application's configuration
```

#### 해결 방안 및 구현 내용

1. **컴파일러 옵션 `-parameters` 추가**: Java 컴파일 시 -parameters` 옵션을 사용해 매개변수 이름 정보를 보존, `@ConfigurationProperties` 바인딩 문제 해결
2. **Gradle 빌드 설정 변경**: `build.gradle`에 `-parameters` 옵션 추가로 프로젝트 빌드 과정 개선
3. **Logback 설정 개선**: `<springProfile>` 태그를 이용해 개발과 프로덕션 환경의 로그 설정 구분, 로그 관리의 명확성 및 효율성 향상
4. **`WARN_OR_MORE_LOG` Appender 추가**: 경고 레벨 이상의 로그 별도 관리를 위해 새 Appender 추가
5. **로그 파일 경로 및 패턴 레이아웃 일관성 개선**: 로그 파일 관리와 추적의 용이성을 위한 조치
6. **`out` 디렉토리 삭제 및 재빌드**: 중복 파일/디렉토리 제거 및 프로젝트 환경 최적화


### 학습 내용 요약:

1. **`@ConfigurationProperties` 이슈 해결**:
   - Spring Boot 3.2.1 버전에서 `@ConfigurationProperties` 어노테이션이 속성 값을 제대로 바인딩하지 못하는 문제를 직면할 수 있음.
   - 문제의 주된 원인은 매개변수의 이름을 인식하지 못하는 것임.
   - 해결책으로, Java 컴파일 시 `-parameters` 옵션을 사용하여 매개변수 이름 정보를 보존하는 방법이 있음. 이는 `@ConfigurationProperties` 바인딩 문제를 해결하는 데 도움이 됨.
2. **Gradle 빌드 설정 변경**:
   - `build.gradle` 파일에 `-parameters` 옵션을 추가하여 프로젝트의 빌드 과정을 개선할 수 있음.
3. **로깅 시스템 개선**:
   - Logback 설정을 개선하여 개발과 프로덕션 환경의 로그 설정을 구분함. 이는 로그 관리의 명확성 및 효율성을 향상시킴.
   - 경고 레벨 이상의 로그를 별도로 관리하기 위한 새로운 Appender (`WARN_OR_MORE_LOG`)를 추가함.
   - 로그 파일 경로 및 패턴 레이아웃의 일관성을 개선하여 로그 파일 관리와 추적의 용이성을 증진시킴.
4. **프로젝트 환경 최적화**:
   - `out` 디렉토리를 삭제하고 프로젝트를 재빌드하여 중복 파일/디렉토리를 제거하고 환경을 최적화함.
